### PR TITLE
locked k factor

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -952,7 +952,7 @@ const clivalue_t valueTable[] = {
     { "rpm_limiter_afterburner_reset",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_rpm_afterburner_reset) },
     { "rpm_limiter_acceleration_limit",    VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 60, 60 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_acceleration_limit) },
     { "rpm_limiter_deceleration_limit",    VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 60, 60 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_deceleration_limit) },
-    { "rpm_limiter_k_factor",    VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 1, 3000 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_k_factor) },
+    { "rpm_limiter_k_factor",    VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 1000, 1000 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_k_factor) },
     { "rpm_limiter_full_linearization",        VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, govenor_rpm_linearization) },
     
     //street league unlocked


### PR DESCRIPTION
This locks the new K factor CLI value for rpm limiter filtering so that it can't be changed by users at a street league event.